### PR TITLE
IssueID #LUC025A-98 Updated ResumableUpload.java to use correct chunk paths when rebuilding the upload

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumableUpload.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/submission/submit/ResumableUpload.java
@@ -836,7 +836,8 @@ public class ResumableUpload extends AbstractAction
 
 				for (int i = 1; i <= this.resumableTotalChunks; i++) 
 				{
-					File fi = new File(chunkPath.concat(Integer.toString(i)));
+					String partId = Integer.toString(i);
+					File fi = new File(chunkPath.concat("[" + partId + ", " + partId + "]"));
 					try 
 					{
 						InputStream is = new FileInputStream(fi);


### PR DESCRIPTION
1) Updated ResumableUpload.makeFileFromChunks to use the new chunk file format when iterating over the chunks