### PR TITLE
LUC025A-103 - Renamed some buttons in the Save & Exit process during the

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/scripts/datashare.js
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/scripts/datashare.js
@@ -211,3 +211,12 @@ $(document).ready(function(){
         }
     }
 });
+
+// Rename buttons in Submission workflow for clarifying Save and Exit process
+$(document).ready(function() {
+	try {
+	   $("#aspect_submission_submit_SaveOrRemoveStep_field_submit_back").html('Continue submission');
+	   $("#aspect_submission_submit_SaveOrRemoveStep_field_submit_save").html('Save and exit');
+	   $("#aspect_submission_submit_SaveOrRemoveStep_field_submit_remove").html('Delete submission');
+	  } catch(E) {}
+});


### PR DESCRIPTION
Submission Workflow to clarify misunderstanding over some Dspace button
names.

Changes:
Using javascript we have changed buttons names from to:

    Ooops, continue submission --> Continue submission
    Save it, I'll work on it later --> Save and exit
    Remove the submission --> Delete submission

![Selection_040](https://user-images.githubusercontent.com/8876215/186199353-869d7843-7150-4f68-9a15-808927c5cb68.png)
