### PR TITLE
LUC025A-99 - Fix to prevent directory upload during Item Submission by

### DIFF
--- a/dspace-xmlui/src/main/webapp/static/js/upload-resumable.js
+++ b/dspace-xmlui/src/main/webapp/static/js/upload-resumable.js
@@ -85,7 +85,7 @@
 		var rdId = 'aspect_submission_StepTransformer_div_resumable-drop';
 		$('#' + rdId + ' p:first').addClass('glyphicon glyphicon-upload');
 		r.assignDrop($('#' + rdId)[0]);
-		r.assignBrowse($('#' + rdId)[0]);
+		r.assignBrowse($('#' + rdId)[0], false); // false prevents selecting directory
 
 		// set up progress bar and button
 		var themePath = window.DSpace.theme_path;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/scripts/resumable.js.original-github-version
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/scripts/resumable.js.original-github-version
@@ -267,10 +267,6 @@
       }else if(item.isDirectory){
         // item is already a directory entry, just assign
         entry = item;
-        cb();
-        // Datashare - start
-        return alert("You cannot upload a directory. Only file selections allowed.");
-        // Datashare - end 
       }else if(item instanceof File) {
         items.push(item);
       }


### PR DESCRIPTION
user.

Changes:
- Had to alter the original Github version of resumable.js.
(Change commented with Datashare - start & end.)
- You can programmatically prevent directory selection at browse phase
with a flag isDirectory false. Not applicable to Drag & Drop. So for
sake of completeness added isDirectory false in Datashare javascript upload-resumable.js:
		r.assignDrop($('#' + rdId)[0]);
		r.assignBrowse($('#' + rdId)[0], false); // false prevents selecting directory
